### PR TITLE
new expandable navigation bar with icons

### DIFF
--- a/src/app/common/svgIcon.js
+++ b/src/app/common/svgIcon.js
@@ -1,0 +1,26 @@
+var icons = {
+  deployments: '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22"> <path fill="#F1F6F7" fill-rule="evenodd" d="M1.85 10.458c-1.481-.74-1.437-1.84.098-2.453l17.299-6.92c1.535-.614 2.282.134 1.668 1.669l-6.92 17.298c-.614 1.536-1.71 1.585-2.453.099l-1.89-3.78c-.74-1.482-2.536-3.28-4.022-4.023l-3.78-1.89z"/> </svg>',
+  gateways: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"> <g fill="#F1F6F7" fill-rule="evenodd"> <rect width="8" height="6" x="6" rx="1"/><rect width="8" height="6" x="1" y="14" rx="1"/><rect width="8" height="6" x="11" y="14" rx="1"/><path d="M0 9h20v2H0zM14 11h2v3h-2zM9 6h2v3H9zM4 11h2v3H4z"/> </g>/svg>',
+  workflows: '<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14"><path fill="none" fill-rule="evenodd" stroke="#F1F6F7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 7.47l1.454-.885C3.4 6.01 4.64 4.783 5.22 3.853L6.803 1.32c.293-.469.636-.416.768.128l2.691 11.046c.131.54.4.57.607.044l2.428-6.134A1.02 1.02 0 0 1 14.6 5.82l.355.132c1.037.388 2.744.925 3.812 1.2L20 7.47"/></svg>',
+  blueprints: '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="0 0 22 20"><g fill="#F1F6F7" fill-rule="evenodd" transform="scale(1 -1) rotate(45 34.678 3.222)"><circle cx="11.5" cy="15.5" r="2.5"/><circle cx="3" cy="16" r="3"/><circle cx="11.5" cy="2.5" r="2.5"/><circle cx="2.5" cy="6.5" r="2.5"/><path fill-rule="nonzero" d="M3 13.401a8.843 8.843 0 0 1 1.949-2.585c3.395-3.108 8.821-3.347 12.65-.876l-.2-.872a.823.823 0 0 1 .14-.666.976.976 0 0 1 .614-.382c.252-.05.516-.006.733.122a.89.89 0 0 1 .422.56l.674 2.965c.103.48-.238.945-.762 1.04l-3.247.615c-.34.064-.69-.042-.921-.278a.83.83 0 0 1-.197-.868.945.945 0 0 1 .724-.59l.955-.181c-3.07-2.025-7.467-1.86-10.211.668C5.71 12.634 4.83 14 4.83 14s-1.873-.599-1.83-.599z"/></g></svg>',
+  breeds: '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="19" height="19" viewBox="0 0 19 19"><defs><path id="a" d="M0 0h20v20H0z"/></defs><g fill="none" fill-rule="evenodd"><mask id="b" fill="#fff"><use xlink:href="#a"/></mask><circle cx="2.5" cy="9.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/><circle cx="9.5" cy="16.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/><circle cx="16.5" cy="2.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/><circle cx="16.5" cy="9.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/><circle cx="9.5" cy="2.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/><circle cx="2.5" cy="16.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/><circle cx="9.5" cy="9.5" r="2.5" fill="#F1F6F7" mask="url(#b)"/></g></svg>',
+  scales: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><g fill="#F1F6F7" fill-rule="evenodd"><rect width="15" height="15" x="5" rx="1"/><path d="M3 10H.995c-.54 0-.995.446-.995.995v8.01c0 .54.446.995.995.995h8.01c.54 0 .995-.446.995-.995V17H4c-.552 0-1-.445-1-1v-6z"/></g></svg>',
+  conditions: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="17" viewBox="0 0 20 17"><g fill="#F1F6F7" fill-rule="evenodd"><rect width="20" height="4" rx="1"/><rect width="10" height="2" x="5" y="15" rx="1"/><rect width="14" height="3" x="3" y="8" rx="1"/></g></svg>',
+  admin: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path fill="#F1F6F7" fill-rule="evenodd" d="M17.372 8.077h1.943c.378 0 .685.306.685.685v2.476a.685.685 0 0 1-.685.685h-1.943c-1.007 0-1.512 1.218-.8 1.93l1.375 1.374a.684.684 0 0 1 0 .968l-1.752 1.752a.684.684 0 0 1-.968 0l-1.374-1.374c-.712-.713-1.93-.208-1.93.8v1.942a.685.685 0 0 1-.685.685H8.762a.685.685 0 0 1-.685-.685v-1.943c0-1.007-1.218-1.512-1.93-.8l-1.374 1.375a.684.684 0 0 1-.968 0l-1.752-1.752a.684.684 0 0 1 0-.968l1.374-1.374c.713-.712.208-1.93-.8-1.93H.686A.685.685 0 0 1 0 11.238V8.762c0-.379.307-.685.685-.685h1.943c1.007 0 1.512-1.218.8-1.93L2.052 4.773a.685.685 0 0 1 0-.969l1.752-1.75a.684.684 0 0 1 .968 0l1.374 1.373c.712.712 1.93.208 1.93-.8V.686c0-.378.306-.685.685-.685h2.476c.379 0 .685.307.685.685v1.943c0 1.007 1.218 1.511 1.93.799l1.374-1.374a.684.684 0 0 1 .968 0l1.752 1.751a.685.685 0 0 1 0 .97l-1.374 1.373c-.713.712-.208 1.93.8 1.93zm-4.218 2a3.077 3.077 0 1 0-6.154 0 3.077 3.077 0 0 0 6.154 0z"/></svg>',
+  nav_expand: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path fill="#F1F6F7" fill-rule="evenodd" d="M13.95 10.707l.707-.707L9 4.343 7.586 5.757 11.828 10l-4.242 4.243L9 15.657l4.95-4.95zM10 20C4.477 20 0 15.523 0 10S4.477 0 10 0s10 4.477 10 10-4.477 10-10 10z"/></svg>',
+  nav_collapse: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path fill="#F1F6F7" fill-rule="evenodd" d="M6.05 10.707L5.343 10 11 4.343l1.414 1.414L8.172 10l4.242 4.243L11 15.657l-4.95-4.95zM10 20c5.523 0 10-4.477 10-10S15.523 0 10 0 0 4.477 0 10s4.477 10 10 10z"/></svg>'
+};
+
+angular.module('vamp-ui').directive('svgicon', function () {
+  function link(scope, element, attrs) {
+    function renderSVG() {
+      element.html(icons[attrs.type]);
+    }
+    renderSVG();
+  }
+
+  return {
+    link: link,
+    restrict: 'E'
+  };
+});

--- a/src/app/menu/menu.js
+++ b/src/app/menu/menu.js
@@ -1,7 +1,7 @@
 /* global VAMP */
 /* eslint dot-notation: ["error", { "allowPattern": "^[a-z]+(_[a-z]+)+$" }] */
 angular.module('vamp-ui').component('menu', {
-  templateUrl: 'app/menu/templates/menu-v2.html',
+  templateUrl: 'app/menu/templates/menu-v3.html',
   controller: MenuController
 });
 
@@ -10,6 +10,30 @@ function MenuController(uiStatesFactory, $state, $timeout) {
 
   $ctrl.leftPanelState = uiStatesFactory.viewStates.left;
   $ctrl.artifacts = VAMP.Artifacts.prototype.all();
+
+  $ctrl.toggleSidebar = function () {
+    if ($ctrl.leftPanelState === uiStatesFactory.STATE_ENUM.COLLAPSED) {
+      uiStatesFactory.setLeftPanelViewState(uiStatesFactory.STATE_ENUM.EXPANDED);
+    } else if ($ctrl.leftPanelState === uiStatesFactory.STATE_ENUM.EXPANDED) {
+      uiStatesFactory.setLeftPanelViewState(uiStatesFactory.STATE_ENUM.COLLAPSED);
+    }
+    $ctrl.leftPanelState = uiStatesFactory.viewStates.left;
+    $('.icon-label').toggleClass('hidden-xs').toggleClass('visible-xs');
+    if (!$ctrl.isPanelExpanded() && $ctrl.adminSubMenu) {
+      $ctrl.toggleAdminSubMenu();
+    }
+  };
+
+  $ctrl.isPanelExpanded = function () {
+    return $ctrl.leftPanelState === uiStatesFactory.STATE_ENUM.EXPANDED;
+  };
+
+  $ctrl.toggleAdminSubMenu = function () {
+    $ctrl.adminSubMenu = !$ctrl.adminSubMenu;
+    if ($ctrl.adminSubMenu && !$ctrl.isPanelExpanded()) {
+      $ctrl.toggleSidebar();
+    }
+  };
 
   $timeout(function () {
     $ctrl.adminSubMenu = $state.includes('admin');

--- a/src/app/menu/side.html
+++ b/src/app/menu/side.html
@@ -7,7 +7,7 @@
 
     <div class="container-fluid">
         <div class="col-sm-4">
-            <a class="side-button" ng-class="{'toggled': $ctrl.pin}" href="" ng-click="$ctrl.pin = !$ctrl.pin">
+            <a class="side-button" href="" ng-click="$ctrl.pin = !$ctrl.pin">
                 <i class="fa fa-thumb-tack" aria-hidden="true"></i>
             </a>
         </div>
@@ -17,13 +17,13 @@
             </a>
         </div>
         <div class="col-sm-4">
-            <i class="fa fa-arrow-right clickable pull-right" aria-hidden="true" ng-click="$ctrl.closePanel()"></i>
+            <i class="fa fa-arrow-right side-button clickable pull-right" aria-hidden="true" ng-click="$ctrl.closePanel()"></i>
         </div>
     </div>
 
     <br><br>
 
-    <div class="" ng-show="$ctrl.uiStates.infoPanel">
+    <div ng-show="$ctrl.uiStates.infoPanel">
         <span class="info-message">{{info.message}}</span>
         <br><br>
         <table class="table">

--- a/src/app/menu/styles/_menu.scss
+++ b/src/app/menu/styles/_menu.scss
@@ -1,6 +1,8 @@
-
 /* Sidebar Styles */
 
+svgicon {
+  display: inline-block;
+}
 
 menu {
   :focus {
@@ -22,12 +24,11 @@ menu {
     padding: 0;
     overflow-y: auto;
     overflow-x: hidden;
-   }
+  }
 
-   li.sidebar-brand {
+  li.sidebar-brand {
     height: $header-height;
     line-height: $header-height;
-    border-bottom: 1px solid $dark-blue;
 
     a {
       padding-left: 2rem;
@@ -44,37 +45,46 @@ menu {
       }
 
       .vamp-logo {
-       height : 4rem;
-       margin-right: 1.8rem;
+        height: 3.5rem;
+        margin-right: 1.8rem;
       }
       .vamp-title {
-       height : 2.9rem;
-       margin-top: 1.1rem
+        height: 2.9rem;
+        margin-top: 1.1rem
       }
     }
-   }
+  }
 
-   ul {
-     list-style: none;
-     font-size: $font-size-normal;
-     font-weight: $font-weight-light;
-		 margin-bottom: 0px;
-		 padding:0;
-		 width:25rem;
-		 margin:0;
+  ul {
+    list-style: none;
+    font-size: 14px;
+    font-weight: $font-weight-light;
+    margin-bottom: 0px;
+    padding: 0;
+    width: 25rem;
+    margin: 0;
 
-		 &.sub-menu {
-       & > li {
-         .btn-link,
-          a {
-            padding-left: 4.5rem;
-            background-color: $night;
-          }
-       }
-		 }
+    li:not(.sidebar-brand):not(.sub-menu-item):nth-of-type(3),
+    li:not(.sidebar-brand):not(.sub-menu-item):nth-of-type(7) {
+      margin-bottom: 50px;
+    }
+
+    li:not(.sidebar-brand):not(.sub-menu-item):last-of-type {
+      margin-top: 160px;
+    }
+
+    &.sub-menu {
+      & > li {
+        .btn-link,
+        a {
+          padding-left: 4.5rem;
+          background-color: $night;
+        }
+      }
+    }
 
     li:not(.sidebar-brand) {
-			user-select:none;
+      user-select: none;
       line-height: 6rem;
       cursor: pointer;
       background-color: $pitch;
@@ -92,38 +102,49 @@ menu {
         text-decoration: none;
 
         & > .btn-link,
-				& > a {
+        & > a {
           padding-left: 2rem;
-				}
-
-        ul.sub-menu {
-          & > li {
-            .btn-link,
-             a {
-               padding-left: 4rem;
-             }
+          & > svgicon {
+            svg {
+              fill: $color-icon-active;
+              g, path {
+                fill: $color-icon-active;
+                stroke: $color-icon-active;
+              }
+            }
           }
         }
-			}
+
+        ul.sub-menu {
+          font-size: 12px;
+          & > li {
+            .btn-link,
+            a {
+              padding-left: 4rem;
+            }
+
+          }
+        }
+      }
 
       &.active:not(.has-sub-menu) {
         & > .btn-link,
-				& > a {
-					text-decoration: none;
-					background-color: $night;
+        & > a {
+          text-decoration: none;
+          background-color: $night;
           font-weight: $font-weight-bold;
           color: $misty;
 
-					&:hover {
-						background-color: $night;
+          &:hover {
+            background-color: $night;
             text-decoration: none;
             font-weight: $font-weight-bold;
             color: $misty;
-					}
-				}
+          }
+        }
       }
 
-			.btn-link,
+      .btn-link,
       a {
         font-weight: $font-weight-light;
         color: $medium-blue;
@@ -132,11 +153,30 @@ menu {
         text-decoration: none;
         transition: padding-left 200ms ease;
 
-        & > span {
-          display: block;
+        & > svgicon {
+          padding-right: 16px;
+          svg {
+            margin-bottom: -6px;
+            width: 20px;
+            height: 20px;
+          }
+          &:not(.collapse-btn) {
+            svg {
+              fill: $color-icon-inactive;
+              g, path {
+                fill: $color-icon-inactive;
+                stroke: $color-icon-inactive;
+              }
+            }
+          }
+        }
 
-          &::first-letter {
-            text-transform: capitalize;
+        & > span {
+          display: inline;
+          text-transform: capitalize;
+
+          & > .icon-dropdown {
+            margin-left: 8rem;
           }
         }
 
@@ -149,8 +189,8 @@ menu {
 
         &:focus {
           text-decoration: none;
-					font-weight: $font-weight-bold;
-					color: $misty;
+          font-weight: $font-weight-bold;
+          color: $misty;
         }
       }
     }

--- a/src/app/menu/templates/menu-v3.html
+++ b/src/app/menu/templates/menu-v3.html
@@ -1,0 +1,63 @@
+<ul>
+    <li class="sidebar-brand">
+        <a href="#">
+            <img class="vamp-logo" src="styles/resources/img/logo.svg">
+        </a>
+    </li>
+</ul>
+<ul class="sidebar-nav">
+    <li
+            ng-repeat="artifact in $ctrl.artifacts"
+            ui-sref="artifacts({kind : artifact.kind, page: 1})" ui-sref-active="active">
+        <a class="btn-link" href="#">
+            <svgicon type="{{artifact.kind}}"></svgicon>
+            <span class="icon-label in hidden-xs">{{artifact.kind}}</span>
+        </a>
+    </li>
+    <li class="has-sub-menu" ui-sref-active="{ 'active': 'admin' }" ng-class="{ 'menu-open' : $ctrl.adminSubMenu}">
+        <a class="btn-link" ng-click="$ctrl.toggleAdminSubMenu()">
+            <svgicon type="admin"></svgicon>
+            <span class="icon-label hidden-xs">
+                Admin
+                <i class="fa fa-caret-down icon-dropdown" ng-if="!$ctrl.adminSubMenu"></i>
+                <i class="fa fa-caret-up icon-dropdown" ng-if="$ctrl.adminSubMenu"></i>
+            </span>
+        </a>
+        <ul class="sub-menu" uib-collapse="!$ctrl.adminSubMenu">
+            <li class="sub-menu-item" ui-sref="admin.configuration" ui-sref-active="active">
+                <a class="btn-link" href="#">
+                    <i></i>
+                    <span>Backend configuration</span>
+                </a>
+            </li>
+            <li class="sub-menu-item" ui-sref="admin.vga" ui-sref-active="active">
+                <a class="btn-link" href="#">
+                    <i></i>
+                    <span>VGA configuration</span>
+                </a>
+            </li>
+            <li class="sub-menu-item" ui-sref="admin.info" ui-sref-active="active">
+                <a class="btn-link" href="#">
+                    <i></i>
+                    <span>Extended info</span>
+                </a>
+            </li>
+            <li class="sub-menu-item" ui-sref="admin.log" ui-sref-active="active">
+                <a class="btn-link" href="#">
+                    <i></i>
+                    <span>Log</span>
+                </a>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <a class="btn-link" ng-click="$ctrl.toggleSidebar()">
+            <svgicon class="collapse-btn" ng-if="$ctrl.isPanelExpanded()" type="nav_collapse"></svgicon>
+            <svgicon class="collapse-btn" ng-if="!$ctrl.isPanelExpanded()" type="nav_expand"></svgicon>
+            <span class="icon-label in hidden-xs">Collapse menu</span>
+        </a>
+    </li>
+</ul>
+
+<div class="sidebar-bottom-docked">
+</div>

--- a/src/styles/_rest.scss
+++ b/src/styles/_rest.scss
@@ -430,11 +430,11 @@ edit, add {
   transition: right 0.3s ease-in-out;
 
   .table tbody tr {
-    vertical-align: bottom;
+    vertical-align: top;
     :nth-child(1) {
       color: $color-text-dark;
       font-size: $font-size-small !important;
-      vertical-align: bottom !important;
+      vertical-align: top !important;
       a {
         color: $color-text;
       }
@@ -1428,22 +1428,9 @@ snippet {
   padding: 5px;
   color: $white;
   text-align: center;
-  text-decoration: underline;
-  &:hover {
-    cursor: pointer;
-    color: $color-bg;
-  }
-  &:focus {
-    color: $white;
-  }
-
-  &.toggled {
-    background-color: rgba(0, 0, 0, 0.3);
-  }
 }
 
 .proxy-anchor {
-  //@extend .side-button;
   cursor: pointer;
   color: #1D96B2;
   font-size: $font-size-normal;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -91,6 +91,9 @@ $color-bg-dark: rgb(20, 45, 60);
 $color-text: $gray-lighter;
 $color-text-dark: $gray-light;
 
+$color-icon-active: #F1F6F7;
+$color-icon-inactive: #7F8FA4;
+
 $font-weight-light: 300;
 $font-weight-regular: 300;
 $font-weight-bold: 500;


### PR DESCRIPTION
Added support for the svg icons to use in the navigation bar and in the whole app. Added menu improvements according to #296 
Fixes:
#217 
#345 
It also fixes partially #384, but handles only the title, the content still can overflow, but I left it on your request to leave card view as it is for now.